### PR TITLE
Show expected and actual secondary headers on import

### DIFF
--- a/main.css
+++ b/main.css
@@ -14,6 +14,13 @@
     display: none;
 }
 
+/* Specify headers modal */
+#specify-headers-comparison-row {
+	overflow-x: auto;
+}
+#expected-headers-div, #actual-headers-div {
+	white-space: pre;
+}
 #specify-headers-err-msg {
 	display: none;
 }

--- a/main.html
+++ b/main.html
@@ -123,8 +123,27 @@
           <div class="modal-body">
             <div class="container-fluid">
               <div class="row">
+                <div class="col">The headers in your imported file do not match the grid.</div>
+              </div>
+              <div class="row my-3">
                 <div class="col">
-                  <p>The headers in your imported file do not match the grid. We will try to map your headers. <b>Which row in your file has the column headers?</b></p>
+                  <div class="row">
+                    <div class="col">Expected headers</div>
+                  </div>
+                  <div class="row">
+                    <div class="col border">foo</div>
+                  </div>
+                  <div class="row">
+                    <div class="col">Actual headers</div>
+                  </div>
+                  <div class="row">
+                    <div class="col border">bar</div>
+                  </div>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col">
+                  <p>We will try to map your headers. <b>Which row in your file has the column headers?</b></p>
                 </div>
               </div>
               <div class="row">

--- a/main.html
+++ b/main.html
@@ -123,21 +123,25 @@
           <div class="modal-body">
             <div class="container-fluid">
               <div class="row">
-                <div class="col">The headers in your imported file do not match the grid.</div>
+                <div class="col">The second row in your imported file does not match the grid.</div>
               </div>
-              <div class="row my-3">
+              <div class="row my-3 border" id="specify-headers-comparison-row">
                 <div class="col">
                   <div class="row">
-                    <div class="col">Expected headers</div>
+                    <div class="col"><b>Expected second row:</b></div>
                   </div>
                   <div class="row">
-                    <div class="col border">foo</div>
+                    <div class="col">
+                      <div id="expected-headers-div"></div>
+                    </div>
                   </div>
                   <div class="row">
-                    <div class="col">Actual headers</div>
+                    <div class="col"><b>Actual second row:</b></div>
                   </div>
                   <div class="row">
-                    <div class="col border">bar</div>
+                    <div class="col">
+                      <div id="actual-headers-div"></div>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/main.js
+++ b/main.js
@@ -353,7 +353,7 @@ const updateSheetRange = (worksheet) => {
 }
 
 /**
- * Determine if a matrix has the same headers as the grid.
+ * Determine if a matrix has the same secondary headers as the grid.
  * @param {Array<Array<String>>} matrix
  * @param {Object} data See `data.js`.
  * @return {Boolean} True if the matrix's second row matches the grid.
@@ -607,6 +607,10 @@ $(document).ready(() => {
             if (compareMatrixHeadersToGrid(matrix, DATA)) {
               HOT.loadData(changeCases(matrix.slice(2), HOT, DATA));
             } else {
+              $('#expected-headers-div')
+                  .html(getFlatHeaders(DATA)[1].join('   '));
+              $('#actual-headers-div')
+                  .html(matrix[1].join('    '));
               $('#specify-headers-modal').modal('show');
               $('#specify-headers-confirm-btn').click(() => {
                 const specifiedHeaderRow =
@@ -628,6 +632,8 @@ $(document).ready(() => {
   });
   // Reset specify header modal values when the modal is closed
   $('#specify-headers-modal').on('hidden.bs.modal', () => {
+    $('#expected-headers-div').empty();
+    $('#actual-headers-div').empty();
     $('#specify-headers-err-msg').hide();
     $('#specify-headers-confirm-btn').unbind();
   });


### PR DESCRIPTION
Fixes #26.

![image](https://user-images.githubusercontent.com/34198261/84085747-1d034500-a99b-11ea-8a33-8b9840347575.png)

Might be useful to highlight differences in red or bold, but this works for now.