### PR TITLE
Addition of pathoplexus to Mpox exports

### DIFF
--- a/web/templates/mpox/export.js
+++ b/web/templates/mpox/export.js
@@ -211,7 +211,7 @@ export default {
       const outputMatrix = [[...exportHeaders.keys()]];
       const sourceFields = dh.slots; //dh.getFields(dh.table);
       const sourceFieldNameMap = dh.getFieldNameMap(sourceFields);
-      dh.getHeaderMap(exportHeaders, sourceFields, 'NCBI_SRA');
+      dh.getHeaderMap(exportHeaders, sourceFields, 'Pathoplexus_Mpox');
       for (const inputRow of dh.getTrimmedData(dh.hot)) {
         const outputRow = [];
         let value;


### PR DESCRIPTION
PR for additional export, pathoplexus_Mpox. The export column was already  present in the slots file, so just needed adding to the export.js. For some reason the whole file is showing as changed but the only change is actually the addition of the 'Pathoplexus_Mpox' export to export.js.